### PR TITLE
prettier console messages

### DIFF
--- a/lib/statistics-panel.js
+++ b/lib/statistics-panel.js
@@ -53,6 +53,7 @@ class StatisticsPanel {
    * @private (api)
    */
   scanAll(amplitude) {
+    console.info("### SCAN REPORT (amplitude: " + amplitude + " s) ###");
     for (var i = 0; i < this.trackedWebsites.length; i++) {
       var url = this.trackedWebsites[i];
       var data = this.dataService.getOver(url, amplitude);
@@ -60,8 +61,9 @@ class StatisticsPanel {
       var statistic = this.processData(data);
       debug("stat", statistic);
       // print it out
-      this.printStatistic(url, amplitude, statistic);
+      console.info("   " + this.prettyStatistics(url, amplitude, statistic));
     }
+    console.info("### ------ ###")
   }
 
   /**
@@ -142,13 +144,14 @@ class StatisticsPanel {
   }
 
   /**
-   * Prints out statistic data in a 'pretty' way.
+   * Creates a "pretty" string out a statistic object.
    * @param {String} url
    * @param {Number} amplitude scan amplitude in seconds
    * @param {Object} statistic
+   * @returns {String}
    * @private (api)
    */
-  printStatistic(url, amplitude, statistic) {
+  prettyStatistics(url, amplitude, statistic) {
     //sanity check
     var availability = statistic.availability !== undefined ? statistic.availability.toFixed(2) : 'NO_DATA';
     var avgSuccessTime = statistic.averageSuccessTime !== undefined ? statistic.averageSuccessTime.toFixed(1) + " (ms)" : 'NO_DATA';
@@ -164,7 +167,7 @@ class StatisticsPanel {
       + "average success time=" + avgSuccessTime + " | "
       + "max success time=" + maxSuccesTime + " | "
       + "min success time=" + minSuccessTime
-    console.info(string);
+    return string;
   }
 
   /**

--- a/test/statistics-panel.test.js
+++ b/test/statistics-panel.test.js
@@ -57,9 +57,10 @@ describe("The StatisticsPanel module: ", function() {
   });
 
   it("scans all websites in tracking list, asking for data over amplitude seconds, processing it then printing it", function() {
+    const consoleInfoStub = this.sandbox.stub(console, 'info');
     const getOverStub = this.sandbox.stub(DataService.prototype, 'getOver').returns([{}]);
     const processDataStub = this.sandbox.stub(StatisticsPanel.prototype, 'processData').returns({});
-    const printStatisticStub = this.sandbox.stub(StatisticsPanel.prototype, 'printStatistic');
+    const prettyStatisticsStub = this.sandbox.stub(StatisticsPanel.prototype, 'prettyStatistics').returns("pretty");
     const dummyDataService = new DataService();
     var statisticsPanel = new StatisticsPanel(dummyDataService);
 
@@ -68,7 +69,8 @@ describe("The StatisticsPanel module: ", function() {
 
     expect(getOverStub).to.have.callCount(0);
     expect(processDataStub).to.have.callCount(0);
-    expect(printStatisticStub).to.have.callCount(0);
+    expect(prettyStatisticsStub).to.have.callCount(0);
+    expect(consoleInfoStub).to.have.callCount(2)
 
     statisticsPanel.trackedWebsites = ["www.google.com", "www.test.com"];
     statisticsPanel.scanAll(100);
@@ -77,8 +79,10 @@ describe("The StatisticsPanel module: ", function() {
     expect(getOverStub).to.have.been.calledWith("www.test.com", 100);
     expect(processDataStub).to.have.callCount(2);
     expect(processDataStub).to.have.been.calledWith([{}]);
-    expect(printStatisticStub).to.have.callCount(2);
-    expect(printStatisticStub).to.have.been.calledWith("www.test.com", 100, {});
+    expect(prettyStatisticsStub).to.have.callCount(2);
+    expect(prettyStatisticsStub).to.have.been.calledWith("www.test.com", 100, {});
+    expect(consoleInfoStub).to.have.callCount(6);
+    expect(consoleInfoStub).to.have.been.calledWith("   pretty"); // three spaces before
   });
 
   it("processes the data from the database into actual stats", function() {
@@ -159,8 +163,7 @@ describe("The StatisticsPanel module: ", function() {
     expect(noSuccessTest).to.deep.equal(noSuccessResult);
   });
 
-  it("prints a (pretty!) info line", function() {
-    const consoleInfoStub = this.sandbox.stub(console, 'info')
+  it("creates a (pretty!) info line", function() {
     const dummyDataService = new DataService();
     const test = {
       availability: 0.4562,
@@ -196,11 +199,11 @@ describe("The StatisticsPanel module: ", function() {
       + "max success time=" + "NO_DATA" + " | "
       + "min success time=" + "NO_DATA";
 
-    statisticsPanel.printStatistic(url, amplitude, test);
-    expect(consoleInfoStub).to.have.been.calledWith(expectedString);
+    var firstTest = statisticsPanel.prettyStatistics(url, amplitude, test);
+    expect(firstTest).to.be.equal(expectedString);
 
-    statisticsPanel.printStatistic(url, amplitude, emptyTest);
-    expect(consoleInfoStub).to.have.been.calledWith(expectedEmptyResult);
+    var secondTest = statisticsPanel.prettyStatistics(url, amplitude, emptyTest);
+    expect(secondTest).to.be.equal(expectedEmptyResult);
   });
 
   it("sets up a scan interval for each element in the scan list", function() {


### PR DESCRIPTION
Refactored `printStatistic()` (returning void) in `prettyStatistics()` (returning string), moved the print statements in `scanAll()` and added spacing/delimiters for a more comfortable viewing on console.